### PR TITLE
Added package classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,19 @@ setup(name='pidfile',
       author_email='bmhatfield@gmail.com',
       url='https://github.com/bmhatfield/python-pidfile.git',
       py_modules=['pidfile'],
+      classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+      ],
       license='MIT'
      )
 


### PR DESCRIPTION
This change adds various package classifiers to setup.py, primarily to indicate Python 3.x support.
